### PR TITLE
Add email verification flow for user registration

### DIFF
--- a/app/controllers/authController.js
+++ b/app/controllers/authController.js
@@ -1,13 +1,23 @@
+const crypto = require('crypto');
 const jwt = require('../config/jwt');
 const {User} = require('../models');
+const emailService = require('../utils/emailService');
 
 function toPlainUser(user) {
   if (!user) {
     return null;
   }
   const plain = typeof user.get === 'function' ? user.get({plain: true}) : {...user};
-  if (plain && Object.prototype.hasOwnProperty.call(plain, 'password')) {
-    delete plain.password;
+  if (plain) {
+    if (Object.prototype.hasOwnProperty.call(plain, 'password')) {
+      delete plain.password;
+    }
+    if (Object.prototype.hasOwnProperty.call(plain, 'emailVerificationToken')) {
+      delete plain.emailVerificationToken;
+    }
+    if (Object.prototype.hasOwnProperty.call(plain, 'emailVerificationTokenExpires')) {
+      delete plain.emailVerificationTokenExpires;
+    }
   }
   return plain;
 }
@@ -22,10 +32,23 @@ module.exports = {
         return res.status(422).json({error: 'Неправильный email'});
       }
 
+      const verificationToken = crypto.randomBytes(32).toString('hex');
+      const parsedTtl = Number(process.env.EMAIL_VERIFICATION_TTL_HOURS);
+      const tokenTtlHours = Number.isFinite(parsedTtl) && parsedTtl > 0 ? parsedTtl : 24;
+      const emailVerificationTokenExpires = new Date(Date.now() + tokenTtlHours * 60 * 60 * 1000);
+
       const user = await User.create({
         name,
         email,
-        password
+        password,
+        emailVerificationToken: verificationToken,
+        emailVerificationTokenExpires,
+        isConfirmed: false
+      });
+
+      await emailService.sendVerificationEmail({
+        to: email,
+        token: verificationToken
       });
 
       const tokens = jwt.generateTokens(user);
@@ -45,11 +68,45 @@ module.exports = {
         return res.status(401).json({error: 'Неправильный email или пароль'});
       }
 
+      if (!user.isConfirmed) {
+        return res.status(403).json({error: 'Аккаунт не подтверждён'});
+      }
+
       const tokens = jwt.generateTokens(user);
 
       res.json({user: toPlainUser(user), token: {...tokens}});
     } catch (error) {
       res.status(500).json({error: 'Login failed'});
+    }
+  },
+
+  async verifyEmail(req, res) {
+    try {
+      const token = req.query.token || req.body?.token;
+
+      if (!token) {
+        return res.status(400).json({error: 'Токен обязателен'});
+      }
+
+      const user = await User.findOne({where: {emailVerificationToken: token}});
+
+      if (!user) {
+        return res.status(400).json({error: 'Неверный токен'});
+      }
+
+      if (!user.emailVerificationTokenExpires || new Date(user.emailVerificationTokenExpires) < new Date()) {
+        return res.status(400).json({error: 'Токен истёк'});
+      }
+
+      user.isConfirmed = true;
+      user.emailVerificationToken = null;
+      user.emailVerificationTokenExpires = null;
+
+      await user.save();
+
+      return res.status(200).json({message: 'Email успешно подтверждён', user: toPlainUser(user)});
+    } catch (error) {
+      return res.status(500).json({error: 'Не удалось подтвердить email'});
     }
   },
 

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -5,7 +5,9 @@ module.exports = (sequelize, DataTypes) => {
         name: DataTypes.STRING,
         birthday: DataTypes.DATEONLY,
         email: { type: DataTypes.STRING, unique: true },
-        isConfirmed: { type: DataTypes.BOOLEAN, allowNull: true, default: true, defaultValue: false },
+        emailVerificationToken: { type: DataTypes.STRING, allowNull: true, field: 'email_verification_token' },
+        emailVerificationTokenExpires: { type: DataTypes.DATE, allowNull: true, field: 'email_verification_token_expires' },
+        isConfirmed: { type: DataTypes.BOOLEAN, allowNull: true, defaultValue: false },
         password: { type: DataTypes.STRING, allowNull: false },
         device_id: { type: DataTypes.STRING, unique: true, allowNull: true }, // Уникальный идентификатор устройства
         is_anonymous: { type: DataTypes.BOOLEAN, defaultValue: false },

--- a/app/routes/authRoutes.js
+++ b/app/routes/authRoutes.js
@@ -4,6 +4,7 @@ const authController = require('../controllers/authController');
 
 router.post('/register', authController.register);
 router.post('/auth', authController.login);
+router.get('/verify-email', authController.verifyEmail);
 router.post('/refresh', authController.refresh);
 router.post('/register-auth', authController.createAnonymousUser);
 router.post('/anonymous-regular', authController.convertToRegularUser);

--- a/app/tests/authController.test.js
+++ b/app/tests/authController.test.js
@@ -1,0 +1,198 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_NAME = process.env.DB_NAME || 'test_db';
+process.env.DB_USER = process.env.DB_USER || 'test_user';
+process.env.DB_PASSWORD = process.env.DB_PASSWORD || 'test_password';
+process.env.DB_HOST = process.env.DB_HOST || 'localhost';
+process.env.DB_PORT = process.env.DB_PORT || '5432';
+process.env.JWT_ACCESS_SECRET = process.env.JWT_ACCESS_SECRET || 'access-secret';
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'refresh-secret';
+
+const test = require('node:test');
+const assert = require('assert');
+
+const models = require('../models');
+const authController = require('../controllers/authController');
+const emailService = require('../utils/emailService');
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    }
+  };
+}
+
+test('register generates verification token and sends email', async () => {
+  const originalFindOne = models.User.findOne;
+  const originalCreate = models.User.create;
+  const originalSendVerificationEmail = emailService.sendVerificationEmail;
+
+  models.User.findOne = async () => null;
+
+  let createdPayload;
+  const createdUser = {
+    id: 1,
+    name: 'John Doe',
+    email: 'john@example.com',
+    is_admin: false,
+    is_anonymous: false,
+    isConfirmed: false,
+    emailVerificationToken: null,
+    emailVerificationTokenExpires: null,
+    get(arg) {
+      if (typeof arg === 'string') {
+        return this[arg];
+      }
+      if (arg && arg.plain) {
+        return {...this};
+      }
+      return {...this};
+    }
+  };
+
+  models.User.create = async (payload) => {
+    createdPayload = payload;
+    Object.assign(createdUser, payload);
+    return createdUser;
+  };
+
+  let emailSent;
+  emailService.sendVerificationEmail = async (data) => {
+    emailSent = data;
+  };
+
+  const req = {body: {name: 'John Doe', email: 'john@example.com', password: 'password123'}};
+  const res = createMockRes();
+
+  try {
+    await authController.register(req, res);
+
+    assert.strictEqual(res.statusCode, 200, 'Should respond with HTTP 200');
+    assert.ok(createdPayload.emailVerificationToken, 'Verification token should be generated');
+    assert.ok(createdPayload.emailVerificationTokenExpires instanceof Date, 'Expiration should be a Date');
+    assert.strictEqual(createdPayload.isConfirmed, false, 'User should be unconfirmed by default');
+    assert.ok(emailSent, 'Verification email should be sent');
+    assert.strictEqual(emailSent.to, 'john@example.com', 'Email should be sent to the user');
+    assert.strictEqual(emailSent.token, createdPayload.emailVerificationToken, 'Email should include token');
+  } finally {
+    models.User.findOne = originalFindOne;
+    models.User.create = originalCreate;
+    emailService.sendVerificationEmail = originalSendVerificationEmail;
+  }
+});
+
+test('verifyEmail confirms user with valid token', async () => {
+  const originalFindOne = models.User.findOne;
+
+  const token = 'valid-token';
+  const user = {
+    id: 2,
+    email: 'valid@example.com',
+    is_admin: false,
+    is_anonymous: false,
+    isConfirmed: false,
+    emailVerificationToken: token,
+    emailVerificationTokenExpires: new Date(Date.now() + 60 * 1000),
+    async save() {
+      return this;
+    },
+    get(arg) {
+      if (typeof arg === 'string') {
+        return this[arg];
+      }
+      if (arg && arg.plain) {
+        return {...this};
+      }
+      return {...this};
+    }
+  };
+
+  models.User.findOne = async ({where}) => {
+    return where.emailVerificationToken === token ? user : null;
+  };
+
+  const req = {query: {token}};
+  const res = createMockRes();
+
+  try {
+    await authController.verifyEmail(req, res);
+
+    assert.strictEqual(res.statusCode, 200, 'Should respond with HTTP 200');
+    assert.strictEqual(user.isConfirmed, true, 'User should be confirmed');
+    assert.strictEqual(user.emailVerificationToken, null, 'Token should be cleared');
+    assert.strictEqual(user.emailVerificationTokenExpires, null, 'Token expiration should be cleared');
+    assert.strictEqual(res.jsonPayload.message, 'Email успешно подтверждён');
+    assert.ok(res.jsonPayload.user, 'Response should include user');
+  } finally {
+    models.User.findOne = originalFindOne;
+  }
+});
+
+test('verifyEmail rejects expired token', async () => {
+  const originalFindOne = models.User.findOne;
+
+  const token = 'expired-token';
+  const user = {
+    id: 3,
+    email: 'expired@example.com',
+    isConfirmed: false,
+    emailVerificationToken: token,
+    emailVerificationTokenExpires: new Date(Date.now() - 60 * 1000),
+    async save() {
+      return this;
+    }
+  };
+
+  models.User.findOne = async ({where}) => {
+    return where.emailVerificationToken === token ? user : null;
+  };
+
+  const req = {query: {token}};
+  const res = createMockRes();
+
+  try {
+    await authController.verifyEmail(req, res);
+
+    assert.strictEqual(res.statusCode, 400, 'Should respond with HTTP 400');
+    assert.strictEqual(res.jsonPayload.error, 'Токен истёк');
+    assert.strictEqual(user.isConfirmed, false, 'User should remain unconfirmed');
+  } finally {
+    models.User.findOne = originalFindOne;
+  }
+});
+
+test('login rejects unconfirmed users', async () => {
+  const originalFindOne = models.User.findOne;
+
+  const user = {
+    id: 4,
+    email: 'pending@example.com',
+    isConfirmed: false,
+    isValidPassword(password) {
+      return password === 'secret';
+    }
+  };
+
+  models.User.findOne = async ({where}) => {
+    return where.email === user.email ? user : null;
+  };
+
+  const req = {body: {email: 'pending@example.com', password: 'secret'}};
+  const res = createMockRes();
+
+  try {
+    await authController.login(req, res);
+
+    assert.strictEqual(res.statusCode, 403, 'Should reject unconfirmed users');
+    assert.strictEqual(res.jsonPayload.error, 'Аккаунт не подтверждён');
+  } finally {
+    models.User.findOne = originalFindOne;
+  }
+});

--- a/app/utils/emailService.js
+++ b/app/utils/emailService.js
@@ -1,0 +1,74 @@
+const nodemailer = require('nodemailer');
+
+let transporter;
+
+function getTransporter() {
+  if (transporter) {
+    return transporter;
+  }
+
+  if (process.env.NODE_ENV === 'test') {
+    transporter = nodemailer.createTransport({
+      jsonTransport: true
+    });
+    return transporter;
+  }
+
+  const requiredEnv = ['SMTP_HOST', 'SMTP_PORT', 'SMTP_USER', 'SMTP_PASSWORD'];
+  const missing = requiredEnv.filter((key) => !process.env[key]);
+
+  if (missing.length) {
+    throw new Error(`Missing SMTP configuration: ${missing.join(', ')}`);
+  }
+
+  transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT),
+    secure: process.env.SMTP_SECURE === 'true' || Number(process.env.SMTP_PORT) === 465,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASSWORD
+    }
+  });
+
+  return transporter;
+}
+
+async function sendEmail({to, subject, text, html}) {
+  const mailTransporter = getTransporter();
+  const from = process.env.SMTP_FROM || process.env.SMTP_USER;
+
+  const mailOptions = {
+    from,
+    to,
+    subject,
+    text,
+    html
+  };
+
+  return mailTransporter.sendMail(mailOptions);
+}
+
+function buildVerificationLink(token) {
+  const baseUrl = process.env.EMAIL_VERIFICATION_URL
+    || `${process.env.APP_URL || 'http://localhost:3000'}/verify-email`;
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}token=${encodeURIComponent(token)}`;
+}
+
+async function sendVerificationEmail({to, token}) {
+  const verificationLink = buildVerificationLink(token);
+
+  const subject = 'Подтверждение email';
+  const text = `Для подтверждения email перейдите по ссылке: ${verificationLink}`;
+  const html = `<p>Для подтверждения email перейдите по ссылке: <a href="${verificationLink}">${verificationLink}</a></p>`;
+
+  await sendEmail({to, subject, text, html});
+}
+
+module.exports = {
+  sendEmail,
+  sendVerificationEmail,
+  buildVerificationLink,
+  getTransporter
+};


### PR DESCRIPTION
## Summary
- add email verification token fields to the user model and hide them from serialized responses
- introduce a reusable SMTP email service and trigger verification mail when registering
- block login for unconfirmed users, add email verification endpoint, and cover the flow with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfc1e44768832ba73a056d04c9639e