### PR TITLE
Add Dolyami payment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,42 @@ YOOKASSA_RETURN_URL=https://example.com/payment/success
 
 Эти параметры используются для инициализации платежей и проверки webhook-уведомлений.
 
+## Интеграция с Долями
+
+Для оформления заказов через сервис рассрочки Долями необходимо указать в `.env`:
+
+```
+DOLYAMI_API_KEY=<API-ключ интеграции>
+DOLYAMI_SHOP_ID=<идентификатор магазина>
+# Необязательно:
+DOLYAMI_API_URL=https://partner.dolyami.ru/api/v1
+DOLYAMI_SUCCESS_URL=https://example.com/payment/success
+DOLYAMI_FAIL_URL=https://example.com/payment/fail
+DOLYAMI_CANCEL_URL=https://example.com/payment/cancel
+DOLYAMI_WEBHOOK_SECRET=<секрет для проверки подписи уведомлений>
+```
+
+- `POST /api/v1/payments/dolyami/webhook` — обработчик уведомлений от Долями.
+- Вызов `POST /api/v1/orders/checkout` должен содержать блок `payment` с указанием метода:
+
+```json
+{
+  "delivery": {
+    "method": "store_pickup",
+    "cost": 0,
+    "address": "г. Москва, ул. Пример, 1"
+  },
+  "payment": {
+    "method": "dolyami",
+    "successUrl": "https://example.com/payment/success",
+    "failUrl": "https://example.com/payment/fail",
+    "cancelUrl": "https://example.com/payment/cancel"
+  }
+}
+```
+
+Если параметр `payment.method` не указан, по умолчанию используется YooKassa (при наличии настроек). В ответе checkout-метода поле `payment` будет содержать `provider: "dolyami"` и ссылку для подтверждения оплаты.
+
 ## Интеграция с СДЭК
 
 Для работы доставки через СДЭК необходимо указать в `.env` следующие параметры:

--- a/app/app.js
+++ b/app/app.js
@@ -23,7 +23,13 @@ const path = require('path');
 
 
 const app = express();
-app.use(express.json());
+app.use(express.json({
+  verify: (req, res, buf) => {
+    if (buf && buf.length) {
+      req.rawBody = Buffer.from(buf);
+    }
+  }
+}));
 
 app.use('/images', express.static(path.join(process.cwd(), 'public', 'images')));
 app.use('/product', express.static(path.join(process.cwd(), 'public', 'product')));

--- a/app/controllers/orderController.js
+++ b/app/controllers/orderController.js
@@ -1,17 +1,19 @@
 const orderService = require('../services/orderService');
 const yookassaService = require('../services/payments/yookassa');
+const dolyamiService = require('../services/payments/dolyami');
 
 exports.checkout = async (req, res) => {
   try {
     const userId = req.user.id;
-    const {delivery, customer, comment, returnUrl} = req.body;
+    const {delivery, customer, comment, returnUrl, payment} = req.body;
 
     const result = await orderService.createOrderFromCart({
       userId,
       delivery,
       customer,
       comment,
-      returnUrl
+      returnUrl,
+      payment
     });
 
     return res.status(201).json({
@@ -64,6 +66,32 @@ exports.handleWebhook = async (req, res) => {
     return res.status(status).json({
       success: false,
       message: error.message || 'Не удалось обработать уведомление'
+    });
+  }
+};
+
+exports.handleDolyamiWebhook = async (req, res) => {
+  try {
+    if (!dolyamiService.isConfigured()) {
+      return res.status(503).json({success: false, message: 'Интеграция Долями не настроена'});
+    }
+
+    const signature = dolyamiService.extractSignature(req.headers);
+    const payloadForSignature = req.rawBody ?? req.body;
+
+    if (!dolyamiService.isValidWebhookSignature({signature, payload: payloadForSignature})) {
+      return res.status(401).json({success: false, message: 'Недействительная подпись уведомления'});
+    }
+
+    await orderService.updateOrderFromDolyamiEvent(req.body);
+
+    return res.json({success: true});
+  } catch (error) {
+    console.error('Dolyami webhook error:', error);
+    const status = error.statusCode || 500;
+    return res.status(status).json({
+      success: false,
+      message: error.message || 'Не удалось обработать уведомление Долями'
     });
   }
 };

--- a/app/routes/orderRoutes.js
+++ b/app/routes/orderRoutes.js
@@ -6,5 +6,6 @@ const orderController = require('../controllers/orderController');
 router.post('/orders/checkout', auth, orderController.checkout);
 router.get('/orders/:slug', auth, orderController.getOrder);
 router.post('/payments/yookassa/webhook', orderController.handleWebhook);
+router.post('/payments/dolyami/webhook', orderController.handleDolyamiWebhook);
 
 module.exports = router;

--- a/app/services/payments/dolyami.js
+++ b/app/services/payments/dolyami.js
@@ -1,0 +1,244 @@
+const axios = require('axios');
+const crypto = require('crypto');
+
+const requiredEnvVars = ['DOLYAMI_API_KEY', 'DOLYAMI_SHOP_ID'];
+
+const isConfigured = () => requiredEnvVars.every(name => Boolean(process.env[name]));
+
+const getConfig = () => {
+  if (!isConfigured()) {
+    throw new Error('Параметры Долями не настроены');
+  }
+
+  return {
+    apiKey: process.env.DOLYAMI_API_KEY,
+    shopId: process.env.DOLYAMI_SHOP_ID,
+    apiUrl: (process.env.DOLYAMI_API_URL || 'https://partner.dolyami.ru/api/v1').replace(/\/$/, ''),
+    successUrl: process.env.DOLYAMI_SUCCESS_URL,
+    failUrl: process.env.DOLYAMI_FAIL_URL,
+    cancelUrl: process.env.DOLYAMI_CANCEL_URL,
+    webhookSecret: process.env.DOLYAMI_WEBHOOK_SECRET
+  };
+};
+
+const createClient = config => {
+  return axios.create({
+    baseURL: `${config.apiUrl}`,
+    headers: {
+      Authorization: `Token ${config.apiKey}`,
+      'X-Shop-Id': config.shopId,
+      'Content-Type': 'application/json'
+    },
+    timeout: 20000
+  });
+};
+
+const normalizeItems = items => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return items.map((item, index) => {
+    const price = Number(item.price ?? item.amount?.value ?? item.amount ?? 0);
+    const quantity = Number(item.quantity ?? item.count ?? 1);
+
+    return {
+      external_id: String(item.external_id ?? item.id ?? item.product_id ?? index + 1),
+      name: String(item.name ?? item.description ?? 'Товар').slice(0, 255),
+      price: Number.isFinite(price) ? price : 0,
+      quantity: Number.isFinite(quantity) ? quantity : 1,
+      total: Number.isFinite(item.total)
+        ? Number(item.total)
+        : Number.isFinite(price * quantity)
+          ? Number((price * quantity).toFixed(2))
+          : 0,
+      sku: item.sku || item.variation_sku || undefined
+    };
+  });
+};
+
+const withOptionalUrls = (payload, config, options = {}) => {
+  if (!payload.success_url && (options.successUrl || config.successUrl)) {
+    payload.success_url = options.successUrl || config.successUrl;
+  }
+
+  if (!payload.fail_url && (options.failUrl || config.failUrl)) {
+    payload.fail_url = options.failUrl || config.failUrl;
+  }
+
+  if (!payload.cancel_url && (options.cancelUrl || config.cancelUrl)) {
+    payload.cancel_url = options.cancelUrl || config.cancelUrl;
+  }
+
+  return payload;
+};
+
+const createOrder = async options => {
+  const config = getConfig();
+  const client = createClient(config);
+
+  const {
+    amount,
+    orderId,
+    orderSlug,
+    description,
+    customer,
+    items,
+    metadata,
+    successUrl,
+    failUrl,
+    cancelUrl,
+    delivery
+  } = options;
+
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new Error('Некорректная сумма заказа для Долями');
+  }
+
+  const payload = withOptionalUrls({
+    order_id: orderSlug || String(orderId),
+    amount: {
+      value: Number(numericAmount.toFixed ? numericAmount.toFixed(2) : numericAmount),
+      currency: 'RUB'
+    },
+    description: description || undefined,
+    customer: customer
+      ? {
+          email: customer.email || undefined,
+          phone: customer.phone || undefined,
+          name: customer.name || undefined
+        }
+      : undefined,
+    items: normalizeItems(items),
+    metadata: metadata || undefined,
+    delivery: delivery || undefined
+  }, config, {successUrl, failUrl, cancelUrl});
+
+  if (!payload.items || !payload.items.length) {
+    delete payload.items;
+  }
+
+  if (!payload.customer) {
+    delete payload.customer;
+  }
+
+  if (!payload.metadata) {
+    delete payload.metadata;
+  }
+
+  if (!payload.delivery) {
+    delete payload.delivery;
+  }
+
+  try {
+    const response = await client.post('/orders', payload);
+    return response.data;
+  } catch (error) {
+    const details = error.response?.data || error.message;
+    const err = new Error('Ошибка при создании заказа в Долями');
+    err.details = details;
+    throw err;
+  }
+};
+
+const getOrder = async orderUuid => {
+  const config = getConfig();
+  const client = createClient(config);
+
+  try {
+    const response = await client.get(`/orders/${orderUuid}`);
+    return response.data;
+  } catch (error) {
+    const details = error.response?.data || error.message;
+    const err = new Error('Ошибка при получении заказа Долями');
+    err.details = details;
+    throw err;
+  }
+};
+
+const cancelOrder = async (orderUuid, reason) => {
+  const config = getConfig();
+  const client = createClient(config);
+
+  try {
+    const response = await client.post(`/orders/${orderUuid}/cancel`, {
+      reason: reason || 'cancelled_by_merchant'
+    });
+    return response.data;
+  } catch (error) {
+    const details = error.response?.data || error.message;
+    const err = new Error('Ошибка при отмене заказа Долями');
+    err.details = details;
+    throw err;
+  }
+};
+
+const extractSignature = headers => {
+  if (!headers) {
+    return null;
+  }
+
+  return headers['x-dolyami-signature']
+    || headers['x-signature']
+    || headers['x-hub-signature-256']?.replace(/^sha256=/, '')
+    || null;
+};
+
+const stringifyPayload = payload => {
+  if (payload === undefined || payload === null) {
+    return '';
+  }
+
+  if (Buffer.isBuffer(payload)) {
+    return payload.toString('utf8');
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (typeof payload === 'object') {
+    try {
+      return JSON.stringify(payload);
+    } catch (error) {
+      return '';
+    }
+  }
+
+  return String(payload);
+};
+
+const calculateSignature = (payload, secret) => {
+  if (!secret) {
+    return null;
+  }
+
+  const raw = stringifyPayload(payload);
+  return crypto.createHmac('sha256', secret).update(raw, 'utf8').digest('hex');
+};
+
+const isValidWebhookSignature = ({signature, payload}) => {
+  const {webhookSecret} = getConfig();
+
+  if (!webhookSecret) {
+    return true;
+  }
+
+  if (!signature) {
+    return false;
+  }
+
+  const expected = calculateSignature(payload, webhookSecret);
+  return Boolean(expected && expected === signature);
+};
+
+module.exports = {
+  isConfigured,
+  createOrder,
+  getOrder,
+  cancelOrder,
+  extractSignature,
+  isValidWebhookSignature,
+  normalizeItems
+};


### PR DESCRIPTION
## Summary
- add a Dolyami payment service with helpers for order creation, cancellation, and webhook signature validation
- update checkout and webhook handling to support selecting Dolyami payments, persist provider metadata, and expose a dedicated webhook endpoint while capturing raw request bodies for signature checks
- document required configuration for the new integration and provide sample payload guidance

## Testing
- npm test *(fails: database connection refused and existing `login rejects unconfirmed users` assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68d10e308bfc832b978d908cba7628ff